### PR TITLE
Reapply "Updates to the jitx imports and simplifying syntax"

### DIFF
--- a/src/circuits.stanza
+++ b/src/circuits.stanza
@@ -4,7 +4,7 @@ defpackage voltage-divider/circuits:
   import jitx
   import jitx/commands
 
-  import jitx/parts/legacy-ocdb-structures
+  import jitx/parts
 
   import voltage-divider/constraints
   import voltage-divider/inverse

--- a/src/constraints.stanza
+++ b/src/constraints.stanza
@@ -3,7 +3,7 @@ defpackage voltage-divider/constraints:
   import core
   import collections
   import jitx
-  import jitx/parts/query-api
+  import jitx/parts
 
   import jsl/ensure
   import jsl/design/settings

--- a/src/inverse.stanza
+++ b/src/inverse.stanza
@@ -3,7 +3,7 @@ defpackage voltage-divider/inverse:
   import core
   import collections
   import jitx
-  import jitx/parts/query-api
+  import jitx/parts
 
   import jsl/ensure
   import jsl/design/settings

--- a/src/solver.stanza
+++ b/src/solver.stanza
@@ -2,17 +2,11 @@
 defpackage voltage-divider/solver:
   import core
   import collections
-  import json
 
-  import jitx with :
-    prefix(Resistor) => EModel-
-    prefix(Capacitor) => EModel-
-    prefix(Inductor) => EModel-
+  import jitx
   import jitx/commands
 
-  import jitx/parts/query-api
-  import jitx/parts/legacy-ocdb-structures
-
+  import jitx/parts
   import jsl/ensure
   import jsl/errors
 
@@ -288,7 +282,7 @@ defn query-resistors (cxt:VoltageDividerConstraints, target: Double, prec:Percen
     limit = query-limit(cxt)
   )
   to-tuple $ for j-obj in j-objs seq:
-    parse-component(j-obj as JObject) as Resistor
+    to-component(j-obj) as Resistor
 
 doc: \<DOC>
 Compute the TCR deviations for the temperature extrema

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -1,14 +1,9 @@
 #use-added-syntax(jitx,tests)
 defpackage voltage-divider/tests/basic:
   import core
-  import jitx with :
-    prefix(Resistor) => EModel-
-    prefix(Capacitor) => EModel-
-    prefix(Inductor) => EModel-
-
+  import jitx
   import jitx/commands
-  import jitx/parts/query-api
-  import jitx/parts/legacy-ocdb-structures
+  import jitx/parts
 
   import jsl/design/settings
 


### PR DESCRIPTION
This reverts commit bfd001cc1f341bc4c192db10c055a2531592a2f0.

This commit should be merged when we have released these features in JITX 3.16

