### PR TITLE
Bugfix on Solver

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "voltage-divider"
-version = "0.4.0"
+version = "0.4.1"
 [dependencies]
 

--- a/src/solver.stanza
+++ b/src/solver.stanza
@@ -184,7 +184,7 @@ defn filter-query-results (
 
     if length(r-his) < min-srcs or length(r-los) < min-srcs :
       println("      Ignoring: there must at least %_ resistors of each type" % [min-srcs])
-      None()
+      return(None())
 
     val r-hi-cmp = r-his[0]
     val r-lo-cmp = r-los[0]
@@ -204,7 +204,7 @@ defn filter-query-results (
 
       println("        min-temp: %_"% [fmt(vo-valids[0], vo-set[0])])
       println("        max-temp: %_" % [fmt(vo-valids[1], vo-set[1])])
-      None()
+      return(None())
 
     println("      Solved: mpn1=%_, mpn2=%_, v-out=(%,V), current=%_A"
             % [mpn(r-hi-cmp), mpn(r-lo-cmp), vo-set, typ-value(vo-set[0]) / low(ratio)])


### PR DESCRIPTION
I was missing a `return()` on the early return entries in the`label` context. The `None()` there was just being lost and the function continued operating instead returning `None()`.

Closes PROD-748
