### PR TITLE
Support JITX 4.2/4.3: stop creating circuit class dynamically

### DIFF
--- a/src/jitxlib/voltage_divider/circuit.py
+++ b/src/jitxlib/voltage_divider/circuit.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 from jitx.component import Component
@@ -44,19 +45,14 @@ class VoltageDividerCircuit(Circuit):
         self.output_voltage = sol.vo
 
 
-def _voltage_divider_instantiable(
-    name: Optional[str] = None,
-) -> type[VoltageDividerCircuit]:
-    """
-    Construct a voltage divider circuit instantiable from a solution.
-    The returned class will have the type name set to `name` if provided.
-    """
-    base_class = VoltageDividerCircuit
+def _warn_name_ignored(name: Optional[str]) -> None:
     if name is not None:
-        # Dynamically create a subclass with the given name
-        return type(name, (VoltageDividerCircuit,), {})
-    else:
-        return base_class
+        warnings.warn(
+            "The `name` argument is deprecated and ignored; the circuit is "
+            "always named 'VoltageDividerCircuit'.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 def voltage_divider(
@@ -64,10 +60,12 @@ def voltage_divider(
 ) -> VoltageDividerCircuit:
     """
     Construct a voltage divider circuit from a solution.
-    The returned class will be an instantiable subclass of VoltageDividerCircuit.
-    The returned class will have the type name set to `name` if provided.
+
+    .. deprecated::
+        The `name` argument is deprecated and ignored.
     """
-    return _voltage_divider_instantiable(name)(sol)
+    _warn_name_ignored(name)
+    return VoltageDividerCircuit(sol)
 
 
 def voltage_divider_from_constraints(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -116,9 +116,7 @@ class TestVoltageDivider(unittest.TestCase):
             base_query=ResistorQuery(mounting="smd", min_stock=10, case=["0402"]),
         )
         with jitx._instantiation.instantiation.activate():
-            circuit = voltage_divider_from_constraints(
-                cxt, name="test_inverse_divider_circuit"
-            )
+            circuit = voltage_divider_from_constraints(cxt)
         build_circuit_from_instance(circuit, "test_inverse_divider_circuit")
 
     # All tests above are integration tests. Here is an example test that actually runs in CI.
@@ -134,10 +132,11 @@ def build_circuit_from_instance(instance: jitx.Circuit, name: str):
         name: Design name
     """
 
+    # Defined here (not during instantiation) so the JITX class is created
+    # outside of any active instantiation context, which JITX 4.2+ requires.
+    # The design name is supplied to builder.build(name=...) directly.
     class TestDesign(SampleDesign):
         circuit = instance
-
-    TestDesign.__name__ = name
 
     builder.build(
         name=name, design=TestDesign, formatter=text_formatter, dump=f"{name}.json"
@@ -154,8 +153,6 @@ def build_circuit(circ: type[jitx.Circuit], name: str):
 
     class TestDesign(SampleDesign):
         circuit = circ()
-
-    TestDesign.__name__ = name
 
     builder.build(
         name=name, design=TestDesign, formatter=text_formatter, dump=f"{name}.json"


### PR DESCRIPTION
## Why
JITX 4.2 added a guard to `Structurable.__init_subclass__` that raises `TypeError("Creating new JITX classes dynamically during instantiation is not supported, ...")`. `voltage_divider()` used `type(name, (VoltageDividerCircuit,), {})` solely to rename the circuit's ESIR module — which now raises when called inside an active instantiation context (as in `test_inverse_divider_circuit`).

## Changes
- **`circuit.py`** — remove `_voltage_divider_instantiable()`; construct `VoltageDividerCircuit` directly. The `name` argument can no longer take effect (per-instance ESIR renaming inherently needs a dynamic subclass, now forbidden during instantiation), so it is **deprecated and ignored** — kept in the signature on `voltage_divider`, `voltage_divider_from_constraints`, `forward_divider`, `inverse_divider`, emitting a `DeprecationWarning`.
- **`tests/test_basic.py`** — drop the redundant `TestDesign.__name__ = name` mutation (the design name is already passed via `builder.build(name=...)`); drop the now-deprecated `name=` argument.

## Verification
- Confirmed on jitx **4.1 / 4.2 / 4.3**: `voltage_divider()` inside an active instantiation no longer raises the dynamic-class `TypeError`; `DeprecationWarning` fires for `name`.
- ruff clean; pyright **0 errors**; unit tier (`pytest -m "not integration"`) passes.

## Dependency note
Full runtime use on 4.2/4.3 also requires a 4.2-compatible `jitxlib-parts` (the `convert_component(...)` call in `__init__` defines a `Component` subclass during instantiation). That is handled separately in JITx-Inc/py-jitx-parts#18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)