### PR TITLE
Fix voltage-divider to use only public parts-DB APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ from jitxlib.voltage_divider import solve
 class ExampleDesign(Design) :
     def __init__(self) :
         solution = solve(cxt)
-        print("High resistor:", solution.R_h)
-        print("Low resistor:", solution.R_l)
+        print("High resistor:", solution.R_h.mpn, solution.R_h.resistance, "ohm")
+        print("Low resistor:", solution.R_l.mpn, solution.R_l.resistance, "ohm")
         print("Output voltage (Toleranced):", solution.vo)
 ```
 

--- a/src/jitxlib/voltage_divider/circuit.py
+++ b/src/jitxlib/voltage_divider/circuit.py
@@ -1,12 +1,10 @@
 import warnings
 from typing import Optional
 
-from jitx.component import Component
 from jitx.circuit import Circuit
-from jitx.inspect import decompose
 from jitx.net import Net, Port
 from jitx.toleranced import Toleranced
-from jitxlib.parts.convert import convert_component
+from jitxlib.parts import Resistor
 
 from .solver import VoltageDividerSolution, solve
 from .constraints import VoltageDividerConstraints
@@ -23,9 +21,8 @@ class VoltageDividerCircuit(Circuit):
     hi: Port
     out: Port
     lo: Port
-    # Make those jitxlib.parts.Resistors for typed attribute accessing.
-    r_hi: Component
-    r_lo: Component
+    r_hi: Resistor
+    r_lo: Resistor
     nets: list[Net]
     output_voltage: Toleranced
 
@@ -34,13 +31,17 @@ class VoltageDividerCircuit(Circuit):
         self.hi = Port()
         self.out = Port()
         self.lo = Port()
-        # Resistor instances
-        self.r_hi = convert_component(sol.R_h.component, component_name="r_hi")()
-        self.r_lo = convert_component(sol.R_l.component, component_name="r_lo")()
-        # Nets (connections)
-        h_p1, h_p2 = decompose(self.r_hi, Port)
-        l_p1, l_p2 = decompose(self.r_lo, Port)
-        self.nets = [h_p1 + self.hi, h_p2 + l_p1 + self.out, l_p2 + self.lo]
+        # Resistor instances, instantiated from the solver's pinned queries via
+        # the public parts factory (safe under active instantiation).
+        self.r_hi = Resistor(sol.R_h.query)
+        self.r_lo = Resistor(sol.R_l.query)
+        # Nets (connections). A resistor is symmetric, so p1/p2 orientation is
+        # electrically irrelevant.
+        self.nets = [
+            self.r_hi.p1 + self.hi,
+            self.r_hi.p2 + self.r_lo.p1 + self.out,
+            self.r_lo.p2 + self.lo,
+        ]
         # FIXME: Properties are a concept of JITX ESIR interface and don't have a port in the python interface.
         self.output_voltage = sol.vo
 

--- a/src/jitxlib/voltage_divider/solver.py
+++ b/src/jitxlib/voltage_divider/solver.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple, cast
 
 from jitx.toleranced import Toleranced
-from jitxlib.parts import search_resistors, ExistKeys, DistinctKey
-from jitxlib.parts._types.main import to_component, PartJSON
-from jitxlib.parts._types.component import MinMax
-from jitxlib.parts._types.resistor import Resistor
+from jitxlib.parts import search_resistors, ExistKeys, DistinctKey, ResistorQuery
+from jitxlib.parts.query_api import to_component
 
 from .constraints import VoltageDividerConstraints
 from .errors import (
@@ -16,14 +14,38 @@ from .errors import (
 )
 
 
+@dataclass(frozen=True)
+class _ResistorData:
+    """Resistor parameters the solver needs from a parts-database entry."""
+
+    resistance: float
+    mpn: str
+    tolerance: Optional[Tuple[float, float]]  # (min, max)
+    tcr: Optional[Tuple[float, float]]  # (pos, neg)
+
+
+@dataclass
+class ResistorSelection:
+    """A resistor chosen by the solver.
+
+    Carries a resolved ``ResistorQuery`` pinned to the exact part (by MPN, with
+    resistance and precision) so the circuit can instantiate it through the
+    public ``jitxlib.parts.Resistor`` factory.
+    """
+
+    resistance: float
+    mpn: str
+    query: ResistorQuery
+
+
 @dataclass
 class VoltageDividerSolution:
     """
     Voltage Divider Solution Type
     """
 
-    R_h: Resistor
-    R_l: Resistor
+    R_h: ResistorSelection
+    R_l: ResistorSelection
     vo: Toleranced
 
 
@@ -126,7 +148,11 @@ def filter_query_results(
     print(
         f"      Solved: mpn1={mpn1}, mpn2={mpn2}, v-out={vout_str}, current={current}A"
     )
-    return VoltageDividerSolution(r_hi_cmp, r_lo_cmp, worst_case_vo)
+    return VoltageDividerSolution(
+        _select(r_hi_cmp, constraints.base_query, precision),
+        _select(r_lo_cmp, constraints.base_query, precision),
+        worst_case_vo,
+    )
 
 
 def sort_pairs_by_best_fit(
@@ -156,7 +182,7 @@ def query_resistance_by_values(
     Returns a list of resistance values (float).
     """
 
-    def to_float(r: PartJSON) -> float:
+    def to_float(r: object) -> float:
         if not isinstance(r, int | float):
             raise ValueError(
                 f"Expected returned resistance value from database to be an int|float, got {type(r)}: {r}"
@@ -180,17 +206,11 @@ def query_resistance_by_values(
 
 def query_resistors(
     constraints: VoltageDividerConstraints, target: float, prec: float
-) -> List[Resistor]:
+) -> List[_ResistorData]:
     """
     Query for resistors matching a particular target resistance and precision.
-    Returns a list of Resistor objects.
+    Returns the parameters the solver needs (resistance, mpn, tolerance, tcr).
     """
-
-    def to_resistor(r: PartJSON) -> Resistor:
-        c = to_component(r)
-        if not isinstance(c, Resistor):
-            raise ValueError(f"Expected Resistor, got {type(c)}: {c}")
-        return c
 
     exist_keys = ExistKeys(["tcr_pos", "tcr_neg"])
     base_query = constraints.base_query
@@ -201,14 +221,42 @@ def query_resistors(
         exist=exist_keys,
         limit=constraints.min_sources,
     )
-    # Convert results to Resistor objects
-    return [to_resistor(r) for r in results]
+    out: List[_ResistorData] = []
+    for r in results:
+        # `to_component` (public, from query_api) parses a parts-db row into a
+        # dataclass; read its fields through a cast so we depend only on the
+        # public function and not on the private result type.
+        c = cast(Any, to_component(r))
+        tol = c.tolerance
+        tcr = c.tcr
+        out.append(
+            _ResistorData(
+                resistance=float(c.resistance),
+                mpn=str(c.mpn),
+                tolerance=(tol.min, tol.max) if tol is not None else None,
+                tcr=(tcr.pos, tcr.neg) if tcr is not None else None,
+            )
+        )
+    return out
+
+
+def _select(
+    chosen: _ResistorData, base_query: ResistorQuery, precision: float
+) -> ResistorSelection:
+    """
+    Build a resolved query pinned to the exact validated part so the circuit
+    instantiates the precise resistor whose TCR/tolerance the solver checked.
+    """
+    query = base_query.update(
+        mpn=chosen.mpn, resistance=chosen.resistance, precision=precision / 100.0
+    )
+    return ResistorSelection(chosen.resistance, chosen.mpn, query)
 
 
 def study_solution(
     constraints: VoltageDividerConstraints,
-    r_hi: Resistor,
-    r_lo: Resistor,
+    r_hi: _ResistorData,
+    r_lo: _ResistorData,
     temp_range: Toleranced,
 ) -> List[Toleranced]:
     """
@@ -242,33 +290,34 @@ def study_solution(
     return results
 
 
-def get_resistance(r: Resistor) -> Toleranced:
+def get_resistance(r: _ResistorData) -> Toleranced:
     """
     Get the resistance value as a Toleranced.
-    Uses the internal information of the Resistor component object to construct the resistance value with tolerances.
-    Raises an error if tolerance is None. Always expects MinMax for tolerance.
+    Combines the nominal resistance with the (min, max) tolerance band.
+    Raises an error if tolerance is None.
     """
     if r.tolerance is None:
         raise ValueError(
-            "Resistor tolerance must be specified (MinMax). None is not allowed."
+            "Resistor tolerance must be specified (min, max). None is not allowed."
         )
     return tol_minmax(r.resistance, r.tolerance)
 
 
-def tol_minmax(typ: float, tolerance: MinMax) -> Toleranced:
+def tol_minmax(typ: float, tolerance: Tuple[float, float]) -> Toleranced:
     """
-    Create a Toleranced value from the MinMax range.
+    Create a Toleranced value from a (min, max) tolerance band.
     Mirrors the Stanza implementation:
     tol(v, tolerance:MinMaxRange):
       coeff = min-max(1.0 + min(tolerance), 1.0 + max(tolerance))
       v * coeff
     """
-    coeff = Toleranced.min_max(1.0 + tolerance.min, 1.0 + tolerance.max)
+    tol_min, tol_max = tolerance
+    coeff = Toleranced.min_max(1.0 + tol_min, 1.0 + tol_max)
     return typ * coeff
 
 
 def compute_tcr_deviation(
-    resistor: Resistor, temperature: float
+    resistor: _ResistorData, temperature: float
 ) -> Optional[Toleranced]:
     """
     Compute the expected deviation window of a given resistor at a given temperature.
@@ -288,7 +337,7 @@ def compute_tcr_deviation(
         return None
     # This mirrors the Stanza hack for database issues:
     # See: https://linear.app/jitx/issue/PROD-328/tcr-values-in-database-seem-wrong
-    p, n = tcr.pos, tcr.neg
+    p, n = tcr
     tcr_interval = Toleranced.min_max(min(p, n), max(p, n))
     return compute_tcr_deviation_interval(tcr_interval, temperature, ref_temp)
 

--- a/src/jitxlib/voltage_divider/solver.py
+++ b/src/jitxlib/voltage_divider/solver.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from logging import getLogger
 from typing import Any, List, Optional, Tuple, cast
 
 from jitx.toleranced import Toleranced
@@ -12,6 +13,9 @@ from .errors import (
     IncompatibleVinVoutError,
     NoSolutionFoundError,
 )
+
+
+logger = getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -87,7 +91,7 @@ def solve(constraints: VoltageDividerConstraints) -> VoltageDividerSolution:
         raise NoPrecisionSatisfiesConstraintsError(goals, pre_screen)
     # Try to solve for each valid precision
     for std_prec in series:
-        print(f"-> Precision {std_prec}%")
+        logger.debug("Trying precision %s%%", std_prec)
         sol = solve_over_series(constraints, std_prec, search_prec)
         if sol is not None:
             return sol
@@ -112,13 +116,14 @@ def solve_over_series(
 def filter_query_results(
     constraints: VoltageDividerConstraints, ratio: Ratio, precision: float
 ) -> Optional[VoltageDividerSolution]:
-    print(f"    - Querying resistors for R-h={ratio.high}Ω R-l={ratio.low}Ω")
+    logger.debug("Querying resistors for R-h=%s ohm R-l=%s ohm", ratio.high, ratio.low)
     r_his = query_resistors(constraints, ratio.high, precision)
     r_los = query_resistors(constraints, ratio.low, precision)
     min_srcs = constraints.min_sources
     if len(r_his) < min_srcs or len(r_los) < min_srcs:
-        print(
-            f"      Ignoring: there must be at least {min_srcs} resistors of each type"
+        logger.debug(
+            "Ignoring candidate: there must be at least %s resistors of each type",
+            min_srcs,
         )
         return None
     r_hi_cmp = r_his[0]
@@ -127,17 +132,16 @@ def filter_query_results(
     vo_valids = [constraints.is_compliant(vo) for vo in vo_set]
     is_valid = all(vo_valids)
     if not is_valid:
-        print("      Ignoring: not a solution when taking into account TCRs.")
+        logger.debug("Ignoring candidate: not a solution when taking TCRs into account")
 
         def fmt(ok, vo):
             return "OK" if ok else f"FAIL ({vo} V)"
 
-        print(f"        min-temp: {fmt(vo_valids[0], vo_set[0])}")
-        print(f"        max-temp: {fmt(vo_valids[1], vo_set[1])}")
+        logger.debug("min-temp: %s", fmt(vo_valids[0], vo_set[0]))
+        logger.debug("max-temp: %s", fmt(vo_valids[1], vo_set[1]))
         return None
     # TODO: Compute the worst case v-out here and use that instead of just the first
     worst_case_vo = vo_set[0]
-    # Print solution found
     mpn1 = r_hi_cmp.mpn
     mpn2 = r_lo_cmp.mpn
     vout_str = f"({vo_set[0]}, {vo_set[1]})V" if len(vo_set) > 1 else f"({vo_set[0]})V"
@@ -145,8 +149,12 @@ def filter_query_results(
         current = vo_set[0].typ / ratio.low
     except Exception:
         current = "unknown"
-    print(
-        f"      Solved: mpn1={mpn1}, mpn2={mpn2}, v-out={vout_str}, current={current}A"
+    logger.info(
+        "Solved: mpn1=%s, mpn2=%s, v-out=%s, current=%sA",
+        mpn1,
+        mpn2,
+        vout_str,
+        current,
     )
     return VoltageDividerSolution(
         _select(r_hi_cmp, constraints.base_query, precision),


### PR DESCRIPTION
## Problem

`jitxlib-voltage-divider` was broken on JITX 4.2 and reached into private parts-DB internals.

1. **Runtime crash (JITX 4.2).** The circuit built resistors with `convert_component(sol.R_h.component, ...)()` inside `VoltageDividerCircuit.__init__`, which runs under an active instantiation context. `convert_component` generates Python source and `exec`s it, **defining a `jitx.Component` subclass** — and 4.2's `Structurable.__init_subclass__` guard forbids defining JITX classes during instantiation, so it raised `TypeError`.
2. **Private-API usage.** `solver.py` imported from `jitxlib.parts._types.*` (`to_component`, `PartJSON`, `MinMax`, `Resistor`) and `circuit.py` from `jitxlib.parts.convert`.

## Changes

**`circuit.py`** — replace the `convert_component` path with the public `jitxlib.parts.Resistor(query)` factory and wire via its `.p1`/`.p2` ports. The public factory is guard-safe: its dynamic landpattern/class-name work is `ClassName(...).assign(...)` data writes over module-scope classes, never a class definition — it's the documented way to instantiate parts inside a `Circuit.__init__`.

**`solver.py`** — public-only:
- `to_component` now imported from the documented public `jitxlib.parts.query_api`.
- The parsed-part fields are read behind a single `cast(Any, ...)` boundary into a local `_ResistorData`, removing the `_types.resistor.Resistor` / `_types.component.MinMax` type dependencies.
- `VoltageDividerSolution` now carries a `ResistorSelection` (resistance, mpn, and a `ResistorQuery` pinned by `mpn` + `resistance` + `precision`) so the circuit instantiates the **exact** part whose TCR/tolerance the solver validated.

**`README.md`** — print `solution.R_h.mpn`/`.resistance` to match the new shape.

## Verification

| Check | Result |
|---|---|
| pyright (`hatch run types:check`) | ✅ 0 errors |
| ruff (`hatch fmt --check`) | ✅ clean |
| `hatch test` (unit) | ✅ pass |
| Offline pipeline + circuit-build fix (parts DB mocked at the `dbquery` seam, real fixture) | ✅ full `solve → Resistor(query)` circuit builds under active instantiation; no crash |

**Not yet run against the real backend.** The parts-DB integration tests need an authorized license, and this host hits a JITX `jitx-machineid` bug: it reports a phantom MAC (`fc:b2:14:91:ab:a8`, not present on the host) while the license is bound to a MAC that *is* present (`8a:9d:e3:47:11:65`), producing a false "license generated for a different device" rejection. That's unrelated to this change and is tracked separately. Once a host with a valid license is available:

```
hatch run python -m jitx runtime start --bg
hatch run python -m jitx runtime status        # grab ws port
<hatch-test env>/python -m tests.test_basic --port <PORT> -v
```

`test_inverse_divider_circuit` is the test that exercises this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
